### PR TITLE
Add link to convert back to username based files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A fork of the original Multiverse-Inventories plugin with UUID support.
 There is no automatic conversion from names to uuids and **all inventories will be lost**.
 To prevent this, you can [convert the files manually](https://github.com/RedstonerServer/old-name-converter).
 
-If you wish to convert back from the UUID files back to username based MV-I 2.5 use this script to convert manually:
+If you wish to convert back from the UUID files back to username based MV-I 2.5 use this script to [convert manually]
 (https://github.com/hockeymikey/DarkStar-Converter).
 
 -----

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ A fork of the original Multiverse-Inventories plugin with UUID support.
 There is no automatic conversion from names to uuids and **all inventories will be lost**.
 To prevent this, you can [convert the files manually](https://github.com/RedstonerServer/old-name-converter).
 
+If you wish to convert back from the UUID files back to username based MV-I 2.5 use this script to convert manually:
+(https://github.com/hockeymikey/DarkStar-Converter).
+
 -----
 
 Copyright (c) 2011, The Multiverse Team All rights reserved.


### PR DESCRIPTION
This script is useful when you want to convert from Multiverse-Inventories to something else (like PerWorldInventories) that only supports the username version.
